### PR TITLE
Added create_uri to helper.rb.

### DIFF
--- a/extras/sipatra/src/main/resources/sipatra/helpers.rb
+++ b/extras/sipatra/src/main/resources/sipatra/helpers.rb
@@ -184,6 +184,12 @@ module Sipatra
         address      
       end
       
+      def create_uri(value, options = {})
+        uri = sip_factory.createURI(value)
+        uri.setLrParam((options.has_key? :lr) ? options[:lr] : true)
+        uri
+      end
+
       def push_route(route)
         message.pushRoute(sip_factory.createAddress(route))
       end    


### PR DESCRIPTION
This method accepts a map to add parameters to the URI to create. For
now, it is only used to choose whether the lr attribute should be set
or not. Considering its common use, lr is added by default.
